### PR TITLE
Add extern "C" { ... } to hagl.h

### DIFF
--- a/include/hagl.h
+++ b/include/hagl.h
@@ -35,6 +35,10 @@ SPDX-License-Identifier: MIT
 #ifndef _HAGL_H
 #define _HAGL_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 #include <stddef.h>
 
@@ -398,5 +402,9 @@ void hagl_clear_screen();
 bitmap_t *hagl_init();
 size_t hagl_flush();
 void hagl_close();
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _HAGL_H */


### PR DESCRIPTION
I was having problems building hagl when included from a cpp project, and found `extern "C"...` was missing from hagl.h, but present in the rest of the headers, so this adds it...