### PR TITLE
Allow drawing scaled chars (hagl_put_scaled_char) and text (hagl_put_scaled_text)

### DIFF
--- a/include/hagl.h
+++ b/include/hagl.h
@@ -92,6 +92,8 @@ color_t hagl_get_pixel(int16_t x0, int16_t y0);
  */
 uint8_t hagl_put_char(wchar_t code, int16_t x0, int16_t y0, color_t color, const unsigned char *font);
 
+uint8_t hagl_put_scaled_char(wchar_t code, int16_t x0, int16_t y0, uint16_t scalefactor, color_t color, const uint8_t *font);
+
 /**
  * Draw a string
  *
@@ -108,6 +110,8 @@ uint8_t hagl_put_char(wchar_t code, int16_t x0, int16_t y0, color_t color, const
  * @return width of the drawn string
  */
 uint16_t hagl_put_text(const wchar_t *str, int16_t x0, int16_t y0, color_t color, const unsigned char *font);
+
+uint16_t hagl_put_scaled_text(const wchar_t *str, int16_t x0, int16_t y0, int16_t scalefactor, color_t color, const unsigned char *font);
 
 /**
  * Extract a glyph into a bitmap

--- a/include/hagl.h
+++ b/include/hagl.h
@@ -92,7 +92,7 @@ color_t hagl_get_pixel(int16_t x0, int16_t y0);
  */
 uint8_t hagl_put_char(wchar_t code, int16_t x0, int16_t y0, color_t color, const unsigned char *font);
 
-uint8_t hagl_put_scaled_char(wchar_t code, int16_t x0, int16_t y0, uint16_t scalefactor, color_t color, const uint8_t *font);
+uint8_t hagl_put_scaled_char(wchar_t code, int16_t x0, int16_t y0, float scalefactor, color_t color, const uint8_t *font);
 
 /**
  * Draw a string
@@ -111,7 +111,7 @@ uint8_t hagl_put_scaled_char(wchar_t code, int16_t x0, int16_t y0, uint16_t scal
  */
 uint16_t hagl_put_text(const wchar_t *str, int16_t x0, int16_t y0, color_t color, const unsigned char *font);
 
-uint16_t hagl_put_scaled_text(const wchar_t *str, int16_t x0, int16_t y0, int16_t scalefactor, color_t color, const unsigned char *font);
+uint16_t hagl_put_scaled_text(const wchar_t *str, int16_t x0, int16_t y0, float scalefactor, color_t color, const unsigned char *font);
 
 /**
  * Extract a glyph into a bitmap

--- a/src/hagl.c
+++ b/src/hagl.c
@@ -339,7 +339,7 @@ uint8_t hagl_put_char(wchar_t code, int16_t x0, int16_t y0, color_t color, const
     return hagl_put_scaled_char(code, x0, y0, 1, color, font);
 }
 
-uint8_t hagl_put_scaled_char(wchar_t code, int16_t x0, int16_t y0, uint16_t scalefactor, color_t color, const uint8_t *font)
+uint8_t hagl_put_scaled_char(wchar_t code, int16_t x0, int16_t y0, float scalefactor, color_t color, const uint8_t *font)
 {
     uint8_t set, status;
     color_t buffer[HAGL_CHAR_BUFFER_SIZE];
@@ -372,13 +372,13 @@ uint8_t hagl_put_scaled_char(wchar_t code, int16_t x0, int16_t y0, uint16_t scal
         glyph.buffer += glyph.pitch;
     }
 
-    if (scalefactor == 1) {
+    if (scalefactor == 1.0) {
         hagl_blit(x0, y0, &bitmap);
     } else {
-        hagl_scale_blit(x0, y0, glyph.width*scalefactor, glyph.height*scalefactor, &bitmap);
+        hagl_scale_blit(x0, y0, (int)glyph.width*scalefactor, (int)glyph.height*scalefactor, &bitmap);
     }
 
-    return bitmap.width*scalefactor;
+    return (int)bitmap.width*scalefactor;
 }
 
 /*
@@ -391,7 +391,7 @@ uint16_t hagl_put_text(const wchar_t *str, int16_t x0, int16_t y0, color_t color
     return hagl_put_scaled_text(str, x0, y0, 1, color, font);
 }
 
-uint16_t hagl_put_scaled_text(const wchar_t *str, int16_t x0, int16_t y0, int16_t scalefactor, color_t color, const unsigned char *font)
+uint16_t hagl_put_scaled_text(const wchar_t *str, int16_t x0, int16_t y0, float scalefactor, color_t color, const unsigned char *font)
 {
     wchar_t temp;
     uint8_t status;
@@ -407,9 +407,9 @@ uint16_t hagl_put_scaled_text(const wchar_t *str, int16_t x0, int16_t y0, int16_
         temp = *str++;
         if (13 == temp || 10 == temp) {
             x0 = 0;
-            y0 += meta.height*scalefactor;
+            y0 += (int)meta.height*scalefactor;
         } else {
-            if (scalefactor == 1) {
+            if (scalefactor == 1.0) {
                 x0 += hagl_put_char(temp, x0, y0, color, font);
             } else {
                 x0 += hagl_put_scaled_char(temp, x0, y0, scalefactor, color, font);

--- a/src/hagl.c
+++ b/src/hagl.c
@@ -336,6 +336,11 @@ uint8_t hagl_get_glyph(wchar_t code, color_t color, bitmap_t *bitmap, const uint
 
 uint8_t hagl_put_char(wchar_t code, int16_t x0, int16_t y0, color_t color, const uint8_t *font)
 {
+    return hagl_put_scaled_char(code, x0, y0, 1, color, font);
+}
+
+uint8_t hagl_put_scaled_char(wchar_t code, int16_t x0, int16_t y0, uint16_t scalefactor, color_t color, const uint8_t *font)
+{
     uint8_t set, status;
     color_t buffer[HAGL_CHAR_BUFFER_SIZE];
     bitmap_t bitmap;
@@ -367,9 +372,13 @@ uint8_t hagl_put_char(wchar_t code, int16_t x0, int16_t y0, color_t color, const
         glyph.buffer += glyph.pitch;
     }
 
-    hagl_blit(x0, y0, &bitmap);
+    if (scalefactor == 1) {
+        hagl_blit(x0, y0, &bitmap);
+    } else {
+        hagl_scale_blit(x0, y0, glyph.width*scalefactor, glyph.height*scalefactor, &bitmap);
+    }
 
-    return bitmap.width;
+    return bitmap.width*scalefactor;
 }
 
 /*
@@ -378,6 +387,11 @@ uint8_t hagl_put_char(wchar_t code, int16_t x0, int16_t y0, color_t color, const
  */
 
 uint16_t hagl_put_text(const wchar_t *str, int16_t x0, int16_t y0, color_t color, const unsigned char *font)
+{
+    return hagl_put_scaled_text(str, x0, y0, 1, color, font);
+}
+
+uint16_t hagl_put_scaled_text(const wchar_t *str, int16_t x0, int16_t y0, int16_t scalefactor, color_t color, const unsigned char *font)
 {
     wchar_t temp;
     uint8_t status;
@@ -393,9 +407,13 @@ uint16_t hagl_put_text(const wchar_t *str, int16_t x0, int16_t y0, color_t color
         temp = *str++;
         if (13 == temp || 10 == temp) {
             x0 = 0;
-            y0 += meta.height;
+            y0 += meta.height*scalefactor;
         } else {
-            x0 += hagl_put_char(temp, x0, y0, color, font);
+            if (scalefactor == 1) {
+                x0 += hagl_put_char(temp, x0, y0, color, font);
+            } else {
+                x0 += hagl_put_scaled_char(temp, x0, y0, scalefactor, color, font);
+            }
         }
     } while (*str != 0);
 


### PR DESCRIPTION
Drawing of text is much too small without scaling (on TTGO T-Display). I tried larger fonts, but were not big enough (and some of the biggest fonts didn't work properly). 