### PR TITLE
Make Pico style CMake definitions the default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,14 @@
 if (ESP_PLATFORM)
+
     idf_component_register(
         SRCS "src/bitmap.c" "src/clip.c" "src/fontx.c" "src/hagl.c"  "src/hsl.c"  "src/rgb565.c"  "src/rgb888.c"  "src/tjpgd.c"
         INCLUDE_DIRS "./include"
         REQUIRES hagl_hal
     )
     add_definitions("-DHAGL_INCLUDE_SDKCONFIG_H")
-endif()
 
-if (PICO_SDK)
+else()
+
     add_library(hagl INTERFACE)
 
     target_sources(hagl INTERFACE
@@ -24,4 +25,5 @@ if (PICO_SDK)
     target_include_directories(hagl INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
     target_link_libraries(hagl INTERFACE hagl_hal)
+
 endif()


### PR DESCRIPTION
Apparently Pico uses standard CMake definitions which work with
other boards such as K210 too.