### PR TITLE
Add possibility to use multiple fps counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## [0.6.0-dev](https://github.com/tuupola/hagl/compare/0.5.0...master)
+
+### Changed
+- The fps counter was refactored ([#69](https://github.com/tuupola/hagl/pull/69)).
+
+
 ## 0.5.0 - 2022-05-19
 
 Initial release.


### PR DESCRIPTION
```c
fps_instance_t fps;
fps_init(&fps);

...

while (1) {
    render_scene();
    hagl_flush(display);
    fps_update(&fps);
    printf("%f fps\r\n", fps.current);
};
```

You can also reset the counter back to zero.

```c
fps_reset(&fps);
```
