### PR TITLE
Add auto wrap text function

### DIFF
--- a/include/hagl/char.h
+++ b/include/hagl/char.h
@@ -37,6 +37,8 @@ SPDX-License-Identifier: MIT
 #define _HAGL_CHAR_H
 
 #include <stdint.h>
+#include <string.h>
+#include "window.h"
 
 #include "hagl/color.h"
 
@@ -81,6 +83,21 @@ hagl_put_char(void const *surface, wchar_t code, int16_t x0, int16_t y0, color_t
  */
 uint16_t
 hagl_put_text(void const *surface, const wchar_t *str, int16_t x0, int16_t y0, color_t color, const unsigned char *font);
+
+/**
+ * Write a string of text that automatically continues to the next line based on the defined window
+ * 
+ * @param surface 
+ * @param text 
+ * @param x0 
+ * @param y0 
+ * @param padding_left 
+ * @param padding_right 
+ * @param color 
+ * @param font 
+ */
+uint8_t
+hagl_put_wrap_text(void const *surface, char text[], hagl_window_t window, color_t color, const unsigned char *font);
 
 /**
  * Extract a glyph into a bitmap


### PR DESCRIPTION
## Overview
Added a function `hagl_put_wrap_text` that will automatically wrap the text to the next line, but without splitting a word into multiple lines. Only full words will be printed on a single line, unless the word is too long to fit. In the scenario where it is too long to fit, it will wrap around mid-word for that word only.

As of now, this was only tested using a small 160x80 ST7735S display with an ESP32 development board.

## Testing
Sample program for testing a few scenarios:
```C
hagl_backend_t *display = hagl_init();
hagl_clear(display);

// Text color
color_t color = hagl_color(display, 255, 255, 255);

// Text to display
char text[] = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed "
    "do eiusmod tempor incididunt ut labore et dolore magna aliqua."
    "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.";

hagl_window_t window_one;
window_one.x0 = 0;
window_one.y0 = 0;
window_one.x1 = 160;
window_one.y1 = 80;

uint8_t result = hagl_put_wrap_text(display, text, window_one, color, font6x9);

/**
 * Narrower bounds
 */
// hagl_window_t window_two;
// window_two.x0 = 50;
// window_two.y0 = 0;
// window_two.x1 = 100;
// window_two.y1 = 80;

// uint8_t result = hagl_put_wrap_text(display, text, window_two, color, font6x9);

/**
 * Testing a word that is longer than the window/screen width. This will be forced to
 * wrap around.
 */
// char long_word[] = "thisisjustaverylongwordthatwillwraparound";
// uint8_t result = hagl_put_wrap_text(display, long_word, window_one, color, font6x9);

if (result > 0) {
    ESP_LOGI(TAG, "Success");
} else {
    ESP_LOGI(TAG, "Window Error");
}

hagl_flush(display);
```