### PR TITLE
incorrect hagl_draw_circle implementation

### DIFF
--- a/src/hagl_circle.c
+++ b/src/hagl_circle.c
@@ -55,13 +55,13 @@ hagl_draw_circle(void const *surface, int16_t xc, int16_t yc, int16_t r, hagl_co
     hagl_put_pixel(surface, xc - y, yc - x, color);
 
     while (y >= x) {
-        x++;
-
         if (d > 0) {
-            y--;
             d = d + 4 * (x - y) + 10;
+            y--;
+            x++;
         } else {
             d = d + 4 * x + 6;
+            x++;
         }
 
         hagl_put_pixel(surface, xc + x, yc + y, color);


### PR DESCRIPTION
very first update 'd' assume 'x=0' and 'y=r' so we can not change them before updating 'd'. I know over internet we can found different versions so I manually checked it on a paper and it seems right.