### PR TITLE
improve draw_circle and fix fill_circle

### DIFF
--- a/include/hagl/circle.h
+++ b/include/hagl/circle.h
@@ -49,26 +49,26 @@ extern "C" {
  *
  * Output will be clipped to the current clip window.
  *
- * @param x0 center X
- * @param y0 center Y
+ * @param xc center X
+ * @param yc center Y
  * @param r radius
  * @param color
  */
 void
-hagl_draw_circle(void const *surface, int16_t x0, int16_t y0, int16_t r, hagl_color_t color);
+hagl_draw_circle(void const *surface, int16_t xc, int16_t yc, int16_t r, hagl_color_t color);
 
 /**
  * Draw a filled circle
  *
  * Output will be clipped to the current clip window.
  *
- * @param x0 center X
- * @param y0 center Y
+ * @param xc center X
+ * @param yc center Y
  * @param r radius
  * @param color
  */
 void
-hagl_fill_circle(void const *surface, int16_t x0, int16_t y0, int16_t r, hagl_color_t color);
+hagl_fill_circle(void const *surface, int16_t xc, int16_t yc, int16_t r, hagl_color_t color);
 
 #ifdef __cplusplus
 }

--- a/src/hagl_circle.c
+++ b/src/hagl_circle.c
@@ -39,7 +39,7 @@ SPDX-License-Identifier: MIT
 #include "hagl/hline.h"
 
 void
-draw_circle_helper_Pixel( int xc, int yc, int x, int y, hagl_color_t color ){
+draw_circle_helper_Pixel(void const *surface, int xc, int yc, int x, int y, hagl_color_t color ){
     hagl_put_pixel(surface, xc+x, yc-y, color ); // UR
     hagl_put_pixel(surface, xc+x, yc+y, color ); // DR
     hagl_put_pixel(surface, xc-x, yc+y, color ); // DL
@@ -51,7 +51,7 @@ draw_circle_helper_Pixel( int xc, int yc, int x, int y, hagl_color_t color ){
 }
 
 void
-draw_circle_helper_Line( int xc, int yc, int x, int y, int len, hagl_color_t color ){
+draw_circle_helper_Line(void const *surface, int xc, int yc, int x, int y, int len, hagl_color_t color ){
     if(len==1){
         draw_circle_helper_Pixel(xc,yc,x-1,y,color);
         return;
@@ -67,7 +67,7 @@ draw_circle_helper_Line( int xc, int yc, int x, int y, int len, hagl_color_t col
 }
 
 void
-draw_circle_helper_URDL( int xc, int yc, int x, int y, int len, hagl_color_t color ){
+draw_circle_helper_URDL(void const *surface, int xc, int yc, int x, int y, int len, hagl_color_t color ){
     if(len==1){
         draw_circle_helper_Pixel(xc,yc,x-1,y,color);
         return;

--- a/src/hagl_circle.c
+++ b/src/hagl_circle.c
@@ -53,7 +53,7 @@ draw_circle_helper_Pixel(void const *surface, int xc, int yc, int x, int y, hagl
 void
 draw_circle_helper_Line(void const *surface, int xc, int yc, int x, int y, int len, hagl_color_t color ){
     if(len==1){
-        draw_circle_helper_Pixel(xc,yc,x-1,y,color);
+        draw_circle_helper_Pixel(surface,xc,yc,x-1,y,color);
         return;
     }
     hagl_draw_hline(surface, xc+x-len, yc-y, len, color ); // UR
@@ -69,7 +69,7 @@ draw_circle_helper_Line(void const *surface, int xc, int yc, int x, int y, int l
 void
 draw_circle_helper_URDL(void const *surface, int xc, int yc, int x, int y, int len, hagl_color_t color ){
     if(len==1){
-        draw_circle_helper_Pixel(xc,yc,x-1,y,color);
+        draw_circle_helper_Pixel(surface,xc,yc,x-1,y,color);
         return;
     }
     hagl_draw_hline(surface, xc-x+1, yc-y, len*2-1, color ); // ULR
@@ -93,9 +93,9 @@ hagl_draw_circle(void const *surface, int16_t xc, int16_t yc, int16_t r, hagl_co
             dx++;
         } else {
             if(edgesDrawed){
-                draw_circle_helper_Line( xc, yc, x+1, y, dx+1, color );
+                draw_circle_helper_Line( surface, xc, yc, x+1, y, dx+1, color );
             } else {
-                draw_circle_helper_URDL( xc, yc, x+1, y, dx+1, color );
+                draw_circle_helper_URDL( surface, xc, yc, x+1, y, dx+1, color );
                 edgesDrawed = 1;
             }
             dx = 0;

--- a/src/hagl_circle.c
+++ b/src/hagl_circle.c
@@ -39,61 +39,93 @@ SPDX-License-Identifier: MIT
 #include "hagl/hline.h"
 
 void
+draw_circle_helper_Pixel( int xc, int yc, int x, int y, hagl_color_t color ){
+    hagl_put_pixel(surface, xc+x, yc-y, color ); // UR
+    hagl_put_pixel(surface, xc+x, yc+y, color ); // DR
+    hagl_put_pixel(surface, xc-x, yc+y, color ); // DL
+    hagl_put_pixel(surface, xc-x, yc-y, color ); // UL
+    hagl_put_pixel(surface, xc+y, yc-x, color ); // RU
+    hagl_put_pixel(surface, xc-y, yc-x, color ); // LU
+    hagl_put_pixel(surface, xc-y, yc+x, color ); // LD
+    hagl_put_pixel(surface, xc+y, yc+x, color ); // RD
+}
+
+void
+draw_circle_helper_Line( int xc, int yc, int x, int y, int len, hagl_color_t color ){
+    if(len==1){
+        draw_circle_helper_Pixel(xc,yc,x-1,y,color);
+        return;
+    }
+    hagl_draw_hline(surface, xc+x-len, yc-y, len, color ); // UR
+    hagl_draw_hline(surface, xc+x-len, yc+y, len, color ); // DR
+    hagl_draw_hline(surface, xc-x+1, yc+y, len, color );   // DL
+    hagl_draw_hline(surface, xc-x+1, yc-y, len, color );   // UL
+    hagl_draw_vline(surface, xc+y, yc-x+1, len, color );   // RU
+    hagl_draw_vline(surface, xc-y, yc-x+1, len, color );   // LU
+    hagl_draw_vline(surface, xc-y, yc+x-len, len, color ); // LD
+    hagl_draw_vline(surface, xc+y, yc+x-len, len, color ); // RD
+}
+
+void
+draw_circle_helper_URDL( int xc, int yc, int x, int y, int len, hagl_color_t color ){
+    if(len==1){
+        draw_circle_helper_Pixel(xc,yc,x-1,y,color);
+        return;
+    }
+    hagl_draw_hline(surface, xc-x+1, yc-y, len*2-1, color ); // ULR
+    hagl_draw_hline(surface, xc-x+1, yc+y, len*2-1, color ); // DLR
+    hagl_draw_vline(surface, xc+y, yc-x+1, len*2-1, color ); // RUD
+    hagl_draw_vline(surface, xc-y, yc-x+1, len*2-1, color ); // LUD
+}
+
+void
 hagl_draw_circle(void const *surface, int16_t xc, int16_t yc, int16_t r, hagl_color_t color)
 {
     int16_t x = 0;
     int16_t y = r;
     int16_t d = 3 - 2 * r;
-
-    hagl_put_pixel(surface, xc + x, yc + y, color);
-    hagl_put_pixel(surface, xc - x, yc + y, color);
-    hagl_put_pixel(surface, xc + x, yc - y, color);
-    hagl_put_pixel(surface, xc - x, yc - y, color);
-    hagl_put_pixel(surface, xc + y, yc + x, color);
-    hagl_put_pixel(surface, xc - y, yc + x, color);
-    hagl_put_pixel(surface, xc + y, yc - x, color);
-    hagl_put_pixel(surface, xc - y, yc - x, color);
-
-    while (y >= x) {
-        if (d > 0) {
-            d = d + 4 * (x - y) + 10;
-            y--;
-            x++;
-        } else {
+    int16_t dx = 0;
+    int16_t edgesDrawed = 0;
+    while( y>=x ){
+        if( d<=0 ){
             d = d + 4 * x + 6;
             x++;
+            dx++;
+        } else {
+            if(edgesDrawed){
+                draw_circle_helper_Line( xc, yc, x+1, y, dx+1, color );
+            } else {
+                draw_circle_helper_URDL( xc, yc, x+1, y, dx+1, color );
+                edgesDrawed = 1;
+            }
+            dx = 0;
+            d = d + 4 * (x - y) + 10;
+            x++;
+            y--;
         }
-
-        hagl_put_pixel(surface, xc + x, yc + y, color);
-        hagl_put_pixel(surface, xc - x, yc + y, color);
-        hagl_put_pixel(surface, xc + x, yc - y, color);
-        hagl_put_pixel(surface, xc - x, yc - y, color);
-        hagl_put_pixel(surface, xc + y, yc + x, color);
-        hagl_put_pixel(surface, xc - y, yc + x, color);
-        hagl_put_pixel(surface, xc + y, yc - x, color);
-        hagl_put_pixel(surface, xc - y, yc - x, color);
     }
 }
 
 void
-hagl_fill_circle(void const *surface, int16_t x0, int16_t y0, int16_t r, hagl_color_t color)
+hagl_fill_circle(void const *surface, int16_t xc, int16_t yc, int16_t r, hagl_color_t color)
 {
     int16_t x = 0;
     int16_t y = r;
     int16_t d = 3 - 2 * r;
 
     while (y >= x) {
-        hagl_draw_hline(surface, x0 - x, y0 + y, x * 2, color);
-        hagl_draw_hline(surface, x0 - x, y0 - y, x * 2, color);
-        hagl_draw_hline(surface, x0 - y, y0 + x, y * 2, color);
-        hagl_draw_hline(surface, x0 - y, y0 - x, y * 2, color);
-        x++;
+        hagl_draw_hline(surface, xc - x, yc + y, x * 2 + 1, color);
+        hagl_draw_hline(surface, xc - x, yc - y, x * 2 + 1, color);
+        hagl_draw_hline(surface, xc - y, yc + x, y * 2 + 1, color);
+        hagl_draw_hline(surface, xc - y, yc - x, y * 2 + 1, color);
 
-        if (d > 0) {
-            y--;
-            d = d + 4 * (x - y) + 10;
-        } else {
+        if( d<=0 ){
             d = d + 4 * x + 6;
+            x++;
+        } else {
+            d = d + 4 * (x - y) + 10;
+            x++;
+            y--;
         }
     }
 }


### PR DESCRIPTION
I improved draw ricle, now it use hline and vline when possible insted of put_pixel. It seems more complex but it reduce wasting time for display communication to minimum. As shown in benchmark below its 2x faster.
I also fix fill circle so they both should produce exactly same circles.
I didnt test this library because I use higly modimied fork of this library, and also I do not know much abot PR yet. If something is wrotn then sorry.

my benchmark code for draw circle:
```
    uint32_t t1,t2;
    t1 = millis();
    for(uint8_t c=0;c<255;c+=5){
        for(int i=0;i<120;i+=2){
            hagl_draw_circle(320/2,120,i,hagl_color_fromRGB(c,c,c));
        }
    }
    t2 = millis();
    printf("%u\n",t2-t1);
    // platform - ESP32 320Mhz
    // display - 320x240 40MHz SPI
    // driver - TFT_eSPI
    // 18932[ms] - standard pixel only
    // 8522[ms] - boosted with hline and vline
```