### PR TITLE
Fix typo in round rectangle example

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ for (uint16_t i = 1; i < 30; i++) {
     hagl_draw_rounded_rectangle(display, x0, y0, x1, y1, r, color);
     hagl_draw_rounded_rectangle_xyxy(display, x0, y0, x1, y1, r, color);
 
-    hagl_draw_rounded_rectangle_xyxy(display, x0, y0, w, h, r, color);
+    hagl_draw_rounded_rectangle_xywh(display, x0, y0, w, h, r, color);
 }
 ```
 


### PR DESCRIPTION
Fix typo in round rectangle: wrong use of function